### PR TITLE
Bump ubuntu base image to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:latest
 
 ENV GDK_BACKEND='broadway'
 ENV BROADWAY_DISPLAY=':5'


### PR DESCRIPTION
It allows to use much more up-to-date packages, e.g. virt-manager 4.0